### PR TITLE
Add 'IfStringComparer' implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![NuGet](https://img.shields.io/nuget/v/Invio.Hashing.svg)](https://www.nuget.org/packages/Invio.Hashing/)
 [![Coverage](https://coveralls.io/repos/github/invio/Invio.Hashing/badge.svg?branch=master)](https://coveralls.io/github/invio/Invio.Hashing?branch=master)
 
-A basic implementation for generating hash codes for data objects.
+A basic implementation for generating hash codes and determing equality for data objects.
 
 # Installation
 The latest version of this package is available on NuGet. To install, run the following command:
@@ -16,7 +16,7 @@ PM> Install-Package Invio.Hashing
 
 # Usage
 
-There is a single class in the package: `HashCode`. By calling one of its `From` implementations, a caller can get consistent hash codes from an unbounded collection of objects, like so:
+This package resolves around a single class: `HashCode`. By calling one of its `From` implementations, a caller can get consistent hash codes from an unbounded collection of objects, like so:
 
 ```csharp
 using Invio.Hashing;
@@ -94,5 +94,49 @@ namespace MyNamespace {
 
 }
 ```
+
+For situations where you wish to avoid using the default `GetHashCode()` implementation for a given object, you can use one of the overloads for `FromList()` or `FromSet()` that take in an `IEqualityComparer` implementation. This is especially helpful in scenarios when comparing strings that respect case-insensivity, like so:
+
+```csharp
+using System;
+using System.Collections.Generic;
+using Invio.Hashing;
+
+namespace MyNamespace {
+
+    public class MyClass : IEquatable<MyClass> {
+    
+        private static StringComparer comparer { get; } = StringComparer.OrdinalIgnoreCase;
+        
+        public String CaseInsensitiveName { get; }
+        public IList<String> CaseInsensitiveItems { get; } = new List<String>();
+        
+        public MyClass(String caseInsensitiveName) {
+            this.CaseInsensitiveName = caseInsensitiveName;
+        }
+
+        public override bool Equals(Object that) {
+            return this.Equals(that as MyClass);
+        }
+
+        public override bool Equals(MyClass that) {
+            return that != null
+                && comparer.Equals(this.CaseInsensitiveName, that.CaseInsensitiveName)
+                && this.CaseInsensitiveItems.SequenceEqual(that.CaseInsensitiveTasks, comparer);
+        }
+
+        public override int GetHashCode() {
+            return HashCode.From(
+                comparer.GetHashCode(this.CaseInsensitiveName),
+                HashCode.FromList(this.CaseInsensitiveItems, comparer)
+            );
+        }
+
+    }
+
+}
+```
+
+There's also [an `IfStringComparer` implementation](src/Invio.Hashing/IfStringComparer.cs) that will take in all objects (instead of exclusively Strings) and only performs case-specific behaviors if the type being evaluated in a String. 
 
 That's it. <3

--- a/src/Invio.Hashing/IfStringComparer.cs
+++ b/src/Invio.Hashing/IfStringComparer.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+
+namespace Invio.Hashing {
+
+    /// <summary>
+    ///   An <see cref="IEqualityComparer{T}" /> implementation that takes in objects.
+    ///   If all of the given objects being evaluated are of type <see cref="String" />,
+    ///   they will use the predefined form of string comparison. Otherwise, the
+    ///   default hash code and equality comparison for each type will be used.
+    /// </summary>
+    public sealed class IfStringComparer : EqualityComparer<Object> {
+
+        /// <summary>
+        ///   Gets an <see cref="IfStringComparer" /> object that performs a case-sensitive
+        ///   string comparison using the word comparison rules of the current culture
+        ///   when <see cref="String" /> objects are found.
+        ///   All other objects, or objects of mixed types, use their default comparison.
+        /// </summary>
+        public static IfStringComparer CurrentCulture { get; }
+
+        /// <summary>
+        ///   Gets an <see cref="IfStringComparer" /> object that performs a case-insensitive
+        ///   string comparison using the word comparison rules of the current culture
+        ///   when <see cref="String" /> objects are found.
+        ///   All other objects, or objects of mixed types, use their default implementations.
+        /// </summary>
+        public static IfStringComparer CurrentCultureIgnoreCase { get; }
+
+        /// <summary>
+        ///   Gets an <see cref="IfStringComparer" /> object that performs a case-sensitive
+        ///   ordinal string comparison when <see cref="String" /> objects are found.
+        ///   All other objects, or objects of mixed types, use their default implementations.
+        /// </summary>
+        public static IfStringComparer Ordinal { get; }
+
+        /// <summary>
+        ///   Gets an <see cref="IfStringComparer" /> object that performs a case-insensitive
+        ///   ordinal string comparison when <see cref="String" /> objects are found.
+        ///   All other objects, or objects of mixed types, use the default comparison.
+        /// </summary>
+        public static IfStringComparer OrdinalIgnoreCase { get; }
+
+        static IfStringComparer() {
+            CurrentCulture =
+                new IfStringComparer(StringComparer.CurrentCulture);
+            CurrentCultureIgnoreCase =
+                new IfStringComparer(StringComparer.CurrentCultureIgnoreCase);
+            Ordinal =
+                new IfStringComparer(StringComparer.Ordinal);
+            OrdinalIgnoreCase =
+                new IfStringComparer(StringComparer.OrdinalIgnoreCase);
+        }
+
+        private IEqualityComparer<String> stringComparer { get; }
+
+        private IfStringComparer(IEqualityComparer<String> stringComparer) {
+            this.stringComparer = stringComparer;
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode(Object that) {
+            if (that == null) {
+                return 0;
+            }
+
+            var thatString = that as String;
+
+            if (thatString != null) {
+                return this.stringComparer.GetHashCode(thatString);
+            }
+
+            return that.GetHashCode();
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(Object left, Object right) {
+            if (left == null || right == null) {
+                return left == null && right == null;
+            }
+
+            var leftString = left as String;
+            var rightString = right as String;
+
+            if (leftString != null && rightString != null) {
+                return this.stringComparer.Equals(leftString, rightString);
+            }
+
+            return left.Equals(right);
+        }
+
+    }
+
+}

--- a/test/Invio.Hashing.Tests/IfStringComparerTests.cs
+++ b/test/Invio.Hashing.Tests/IfStringComparerTests.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Invio.Hashing {
+
+    public class IfStringComparerTests {
+
+        [Theory]
+        [MemberData(nameof(NeverEqual_Data))]
+        [MemberData(nameof(CaseInsensitiveEqual_Data))]
+        public void CurrentCulture_NotEqual(Object left, Object right) {
+
+            // Arrange
+
+            var comparer = IfStringComparer.CurrentCulture;
+
+            // Act
+
+            var isEqual = comparer.Equals(left, right);
+
+            // Assert
+
+            Assert.False(isEqual);
+        }
+
+        [Theory]
+        [MemberData(nameof(AlwaysEqual_Data))]
+        public void CurrentCulture_Equal(Object left, Object right) {
+
+            // Arrange
+
+            var comparer = IfStringComparer.CurrentCulture;
+
+            // Act
+
+            var isEqual = comparer.Equals(left, right);
+            var leftHashCode = comparer.GetHashCode(left);
+            var rightHashCode = comparer.GetHashCode(right);
+
+            // Assert
+
+            Assert.True(isEqual);
+            Assert.Equal(leftHashCode, rightHashCode);
+        }
+
+        [Theory]
+        [MemberData(nameof(NeverEqual_Data))]
+        public void CurrentCultureIgnoreCase_NotEqual(Object left, Object right) {
+
+            // Arrange
+
+            var comparer = IfStringComparer.CurrentCultureIgnoreCase;
+
+            // Act
+
+            var isEqual = comparer.Equals(left, right);
+
+            // Assert
+
+            Assert.False(isEqual);
+        }
+
+        [Theory]
+        [MemberData(nameof(AlwaysEqual_Data))]
+        [MemberData(nameof(CaseInsensitiveEqual_Data))]
+        public void CurrentCultureIgnoreCase_Equal(Object left, Object right) {
+
+            // Arrange
+
+            var comparer = IfStringComparer.CurrentCultureIgnoreCase;
+
+            // Act
+
+            var isEqual = comparer.Equals((String)left, (String)right);
+            var leftHashCode = comparer.GetHashCode(left);
+            var rightHashCode = comparer.GetHashCode(right);
+
+            // Assert
+
+            Assert.True(isEqual);
+            Assert.Equal(leftHashCode, rightHashCode);
+        }
+
+        [Theory]
+        [MemberData(nameof(NeverEqual_Data))]
+        [MemberData(nameof(CaseInsensitiveEqual_Data))]
+        public void Ordinal_NotEqual(Object left, Object right) {
+
+            // Arrange
+
+            var comparer = IfStringComparer.Ordinal;
+
+            // Act
+
+            var isEqual = comparer.Equals(left, right);
+
+            // Assert
+
+            Assert.False(isEqual);
+        }
+
+        [Theory]
+        [MemberData(nameof(AlwaysEqual_Data))]
+        public void Ordinal_Equal(Object left, Object right) {
+
+            // Arrange
+
+            var comparer = IfStringComparer.Ordinal;
+
+            // Act
+
+            var isEqual = comparer.Equals(left, right);
+            var leftHashCode = comparer.GetHashCode(left);
+            var rightHashCode = comparer.GetHashCode(right);
+
+            // Assert
+
+            Assert.True(isEqual);
+            Assert.Equal(leftHashCode, rightHashCode);
+        }
+
+        [Theory]
+        [MemberData(nameof(NeverEqual_Data))]
+        public void OrdinalIgnoreCase_NotEqual(Object left, Object right) {
+
+            // Arrange
+
+            var comparer = IfStringComparer.OrdinalIgnoreCase;
+
+            // Act
+
+            var isEqual = comparer.Equals(left, right);
+
+            // Assert
+
+            Assert.False(isEqual);
+        }
+
+        [Theory]
+        [MemberData(nameof(AlwaysEqual_Data))]
+        [MemberData(nameof(CaseInsensitiveEqual_Data))]
+        public void OrdinalIgnoreCase_Equal(Object left, Object right) {
+
+            // Arrange
+
+            var comparer = IfStringComparer.OrdinalIgnoreCase;
+
+            // Act
+
+            var isEqual = comparer.Equals((String)left, (String)right);
+            var leftHashCode = comparer.GetHashCode(left);
+            var rightHashCode = comparer.GetHashCode(right);
+
+            // Assert
+
+            Assert.True(isEqual);
+            Assert.Equal(leftHashCode, rightHashCode);
+        }
+
+        public static IEnumerable<object[]> AlwaysEqual_Data {
+            get {
+                return new List<object[]> {
+                    new object[] { null, null },
+                    new object[] { "", "" },
+                    new object[] { "Foo", "Foo" }
+                };
+            }
+        }
+
+        public static IEnumerable<object[]> NeverEqual_Data {
+            get {
+                return new List<object[]> {
+                    new object[] { null, "Foo" },
+                    new object[] { 65, "A" },
+                    new object[] { 'A', "A" },
+                    new object[] { 5, 6 },
+                    new object[] { Guid.NewGuid(), Guid.NewGuid() },
+                    new object[] { new object(), null }
+                };
+            }
+        }
+
+        public static IEnumerable<object[]> CaseInsensitiveEqual_Data {
+            get {
+                return new List<object[]> {
+                    new object[] { "Foo", "FOO" },
+                    new object[] { "BaR", "bar" }
+                };
+            }
+        }
+
+    }
+
+}


### PR DESCRIPTION
Adds an 'IfStringComparer' concept to ease case-insensitive comparisons when strings are one of many types in an IEnumerable

Fixes #8 