### PR TITLE
Cleanup repository for CI

### DIFF
--- a/Invio.Hashing.sln
+++ b/Invio.Hashing.sln
@@ -1,0 +1,56 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{A05F6411-BFFD-42D3-8A14-9060D5925E8D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Invio.Hashing", "src\Invio.Hashing\Invio.Hashing.csproj", "{9BEB37B6-EB47-4F95-A971-DDE7B3CBDB41}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{A0EC20F4-522C-4CE6-B143-F5DFB78BE0C4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Invio.Hashing.Tests", "test\Invio.Hashing.Tests\Invio.Hashing.Tests.csproj", "{03156BAA-3274-4ACC-8C58-ED2B7865D950}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9BEB37B6-EB47-4F95-A971-DDE7B3CBDB41}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9BEB37B6-EB47-4F95-A971-DDE7B3CBDB41}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9BEB37B6-EB47-4F95-A971-DDE7B3CBDB41}.Debug|x64.ActiveCfg = Debug|x64
+		{9BEB37B6-EB47-4F95-A971-DDE7B3CBDB41}.Debug|x64.Build.0 = Debug|x64
+		{9BEB37B6-EB47-4F95-A971-DDE7B3CBDB41}.Debug|x86.ActiveCfg = Debug|x86
+		{9BEB37B6-EB47-4F95-A971-DDE7B3CBDB41}.Debug|x86.Build.0 = Debug|x86
+		{9BEB37B6-EB47-4F95-A971-DDE7B3CBDB41}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9BEB37B6-EB47-4F95-A971-DDE7B3CBDB41}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9BEB37B6-EB47-4F95-A971-DDE7B3CBDB41}.Release|x64.ActiveCfg = Release|x64
+		{9BEB37B6-EB47-4F95-A971-DDE7B3CBDB41}.Release|x64.Build.0 = Release|x64
+		{9BEB37B6-EB47-4F95-A971-DDE7B3CBDB41}.Release|x86.ActiveCfg = Release|x86
+		{9BEB37B6-EB47-4F95-A971-DDE7B3CBDB41}.Release|x86.Build.0 = Release|x86
+		{03156BAA-3274-4ACC-8C58-ED2B7865D950}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{03156BAA-3274-4ACC-8C58-ED2B7865D950}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{03156BAA-3274-4ACC-8C58-ED2B7865D950}.Debug|x64.ActiveCfg = Debug|x64
+		{03156BAA-3274-4ACC-8C58-ED2B7865D950}.Debug|x64.Build.0 = Debug|x64
+		{03156BAA-3274-4ACC-8C58-ED2B7865D950}.Debug|x86.ActiveCfg = Debug|x86
+		{03156BAA-3274-4ACC-8C58-ED2B7865D950}.Debug|x86.Build.0 = Debug|x86
+		{03156BAA-3274-4ACC-8C58-ED2B7865D950}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{03156BAA-3274-4ACC-8C58-ED2B7865D950}.Release|Any CPU.Build.0 = Release|Any CPU
+		{03156BAA-3274-4ACC-8C58-ED2B7865D950}.Release|x64.ActiveCfg = Release|x64
+		{03156BAA-3274-4ACC-8C58-ED2B7865D950}.Release|x64.Build.0 = Release|x64
+		{03156BAA-3274-4ACC-8C58-ED2B7865D950}.Release|x86.ActiveCfg = Release|x86
+		{03156BAA-3274-4ACC-8C58-ED2B7865D950}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{9BEB37B6-EB47-4F95-A971-DDE7B3CBDB41} = {A05F6411-BFFD-42D3-8A14-9060D5925E8D}
+		{03156BAA-3274-4ACC-8C58-ED2B7865D950} = {A0EC20F4-522C-4CE6-B143-F5DFB78BE0C4}
+	EndGlobalSection
+EndGlobal

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,7 @@ nuget:
 build_script:
 - ps: .\build.ps1
 after_build:
+- ps: .\set-debug-type.ps1
 - ps: .\coverage.ps1
 test: off
 artifacts:

--- a/build.ps1
+++ b/build.ps1
@@ -52,15 +52,12 @@ if(Test-Path .\artifacts) { Remove-Item .\artifacts -Force -Recurse }
 
 EnsurePsbuildInstalled
 
-exec { & dotnet restore .\src\Invio.Hashing }
-exec { & dotnet restore .\test\Invio.Hashing.Tests }
-
-exec { & dotnet build .\src\Invio.Hashing }
-exec { & dotnet build .\test\Invio.Hashing.Tests }
+exec { & dotnet restore }
+exec { & dotnet build }
 
 $revision = @{ $true = $env:APPVEYOR_BUILD_NUMBER; $false = 1 }[$env:APPVEYOR_BUILD_NUMBER -ne $NULL];
 $revision = "{0:D4}" -f [convert]::ToInt32($revision, 10)
 
 exec { & dotnet test .\test\Invio.Hashing.Tests\Invio.Hashing.Tests.csproj -c Release }
 
-exec { & dotnet pack .\src\Invio.Hashing -c Release -o ..\..\artifacts }
+exec { & dotnet pack -c Release -o ..\..\artifacts }

--- a/build.sh
+++ b/build.sh
@@ -9,9 +9,8 @@ if [ -d $artifactsFolder ]; then
   rm -R $artifactsFolder
 fi
 
-dotnet restore ./src/Invio.Hashing
-dotnet restore ./test/Invio.Hashing.Tests
+dotnet restore
 
 dotnet test ./test/Invio.Hashing.Tests/Invio.Hashing.Tests.csproj -c Release -f netcoreapp1.0
 
-dotnet pack ./src/Invio.Hashing -c Release -o ../../artifacts
+dotnet pack -c Release -o ../../artifacts

--- a/set-debug-type.ps1
+++ b/set-debug-type.ps1
@@ -1,0 +1,8 @@
+$projectName = "Invio.Hashing"
+
+copy 'src\${projectName}\${projectName}.csproj' 'src\${projectName}\${projectName}.csproj.bak'
+
+$project = New-Object XML
+$project.Load("${pwd}\src\${projectName}\${projectName}.csproj")
+$project.Project.PropertyGroup.DebugType = "full"
+$project.Save("${pwd}\src\${projectName}\${projectName}.csproj")

--- a/set-debug-type.ps1
+++ b/set-debug-type.ps1
@@ -1,6 +1,6 @@
 $projectName = "Invio.Hashing"
 
-copy 'src\${projectName}\${projectName}.csproj' 'src\${projectName}\${projectName}.csproj.bak'
+copy "src\${projectName}\${projectName}.csproj" "src\${projectName}\${projectName}.csproj.bak"
 
 $project = New-Object XML
 $project.Load("${pwd}\src\${projectName}\${projectName}.csproj")

--- a/src/Invio.Hashing/Invio.Hashing.csproj
+++ b/src/Invio.Hashing/Invio.Hashing.csproj
@@ -5,7 +5,7 @@
     <VersionPrefix>1.3.2</VersionPrefix>
     <Authors>Brian Caruso &lt;brian@invioinc.com&gt;</Authors>
     <TargetFramework>netstandard1.2</TargetFramework>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Invio.Hashing</AssemblyName>
     <PackageId>Invio.Hashing</PackageId>

--- a/test/Invio.Hashing.Tests/Invio.Hashing.Tests.csproj
+++ b/test/Invio.Hashing.Tests/Invio.Hashing.Tests.csproj
@@ -12,6 +12,7 @@
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
       1.1.1
     </RuntimeFrameworkVersion>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,8 +21,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-*" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-*" />
-    <PackageReference Include="xunit" Version="2.2.0-*" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">


### PR DESCRIPTION
Closes #18 

Improves `dotnet` CLI developer ergonomics
Improves symbol export via `<DebugType>` of `portable`