### PR TITLE
Clean-up netstandard, Apply Xunit categories

### DIFF
--- a/src/Invio.Hashing/Invio.Hashing.csproj
+++ b/src/Invio.Hashing/Invio.Hashing.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <Description>Utilities for generating hashes and hashcodes</Description>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>0.1.3</VersionPrefix>
     <Authors>Invio Inc &lt;developers@invioinc.com&gt;</Authors>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard1.0</TargetFramework>
     <DebugType>portable</DebugType>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Invio.Hashing</AssemblyName>

--- a/test/Invio.Hashing.Tests/HashCodeTests.cs
+++ b/test/Invio.Hashing.Tests/HashCodeTests.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using Invio.Xunit;
 using Xunit;
 
 namespace Invio.Hashing {
 
-    public class HashCodeTests {
+    [UnitTest]
+    public sealed class HashCodeTests {
 
         public static IEnumerable<object[]> Consistency_Data {
             get {

--- a/test/Invio.Hashing.Tests/IfStringComparerTests.cs
+++ b/test/Invio.Hashing.Tests/IfStringComparerTests.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Generic;
+using Invio.Xunit;
 using Xunit;
 
 namespace Invio.Hashing {
 
-    public class IfStringComparerTests {
+    [UnitTest]
+    public sealed class IfStringComparerTests {
 
         [Theory]
         [MemberData(nameof(NeverEqual_Data))]

--- a/test/Invio.Hashing.Tests/Invio.Hashing.Tests.csproj
+++ b/test/Invio.Hashing.Tests/Invio.Hashing.Tests.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Invio.Xunit" Version="0.1.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="xunit" Version="2.3.1" />


### PR DESCRIPTION
Since `netstandard1.0` [is compatible with .NET Core v2](http://immo.landwerth.net/netstandard-versions/), there's no reason for this to have been bumped up to `netstandard2.0`. Reverting it back to `netstandard1.0`.

Additionally, this project's test suite didn't use the `Invio.Xunit` attributions, which the rest of our open source projects use. I plugged it in for consistency.