### PR TITLE
Migrate tests and CI to .NET Core v2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: csharp
 sudo: required
-dotnet: 2.0.3
+dotnet: 2.1.300
 
 matrix:
   include:

--- a/test/Invio.Hashing.Tests/Invio.Hashing.Tests.csproj
+++ b/test/Invio.Hashing.Tests/Invio.Hashing.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>Invio.Hashing.Tests</AssemblyName>
     <PackageId>Invio.Hashing.Tests</PackageId>
@@ -9,9 +9,7 @@
     <AssetTargetFallback>
       $(AssetTargetFallback);dotnet5.4;portable-net451+win8
     </AssetTargetFallback>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
-      2.0.3
-    </RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>2.1.0</RuntimeFrameworkVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -21,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Invio.Xunit" Version="0.1.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="xunit" Version="2.3.1" />
   </ItemGroup>


### PR DESCRIPTION
Migrated project and CI configuration to .NET Core v2.1. Runs locally with the new SDK as well.